### PR TITLE
Check length `to` parameter

### DIFF
--- a/contracts/java/token/src/ai/effect/token/EffectToken.java
+++ b/contracts/java/token/src/ai/effect/token/EffectToken.java
@@ -64,6 +64,7 @@ public class EffectToken extends SmartContract
      */
     public static boolean transfer(byte[] from, byte[] to, BigInteger value, byte[] caller) {
     	if (value.compareTo(BigInteger.ZERO) <= 0) return false;
+	if (to.length != 20) return false;
 	if (!checkWitness(from, caller)) return false;
 
 	BigInteger fromValue = getBalance(from);


### PR DESCRIPTION
It is possible to write arbitrary values on the storage. 
Because the `to` parameter length is not checked so, it is possible to write any value.  This could be very dangerous