### PR TITLE
Checks before the transfer

### DIFF
--- a/contracts/java/token-lock/src/ai/effect/token/TokenLock.java
+++ b/contracts/java/token-lock/src/ai/effect/token/TokenLock.java
@@ -52,14 +52,12 @@ public class TokenLock extends SmartContract
      */
     public static Object lock(byte[] from, byte[] to, BigInteger value, BigInteger lockHeight) {
 	if (value.compareTo(BigInteger.ZERO) < 0) return "amount not positive";
-
+	if (to.length != 20) return "invalid address";
 	if (lockHeight.intValue() <= Blockchain.height()) return "already unlocked";
 
 	byte[] lockAddress = getAddress();
 	boolean transferred = (boolean) token("transfer", new Object[] {from, lockAddress, value});
 	if (transferred == false) return "transfer failed";
-
-	if (to.length != 20) return "invalid address";
 
 	byte[] lockKey = Helper.concat(to, lockHeight.toByteArray());
 	BigInteger lockValue = new BigInteger(Storage.get(Storage.currentContext(), lockKey));

--- a/contracts/java/token-lock/src/ai/effect/token/TokenLock.java
+++ b/contracts/java/token-lock/src/ai/effect/token/TokenLock.java
@@ -51,7 +51,7 @@ public class TokenLock extends SmartContract
      * Send `amount` of tokens to an address that are locked until `height`
      */
     public static Object lock(byte[] from, byte[] to, BigInteger value, BigInteger lockHeight) {
-	if (value.compareTo(BigInteger.ZERO) < 0) return "amount not positive";
+	if (value.compareTo(BigInteger.ZERO) <= 0) return "amount not positive";
 	if (to.length != 20) return "invalid address";
 	if (lockHeight.intValue() <= Blockchain.height()) return "already unlocked";
 


### PR DESCRIPTION
It is possible to transfer a Token  to `lockAddress`, and then burn this token with incorrect `to` address value