### PR TITLE
Save ops with balance check

### DIFF
--- a/contracts/java/token/src/ai/effect/token/EffectToken.java
+++ b/contracts/java/token/src/ai/effect/token/EffectToken.java
@@ -84,9 +84,10 @@ public class EffectToken extends SmartContract
         if (!Runtime.checkWitness(from)) return false;
 
         BigInteger fromValue = getBalance(from);
-        byte[] fromKey = storageKey(PREFIX_BALANCE, from);
 
         if (fromValue.compareTo(value) < 0) return false;
+
+        byte[] fromKey = storageKey(PREFIX_BALANCE, from);
 
         storageSubtractOrDelete(fromKey, fromValue, value);
 
@@ -115,9 +116,10 @@ public class EffectToken extends SmartContract
         if (allowanceValue.compareTo(value) < 0) return false;
 
         BigInteger fromValue = getBalance(from);
-        byte[] fromKey = storageKey(PREFIX_BALANCE, from);
 
         if (fromValue.compareTo(value) < 0) return false;
+
+        byte[] fromKey = storageKey(PREFIX_BALANCE, from);
 
         storageSubtractOrDelete(fromKey, fromValue, value);
 
@@ -190,9 +192,10 @@ public class EffectToken extends SmartContract
         if (!Runtime.checkWitness(from)) return false;
 
         BigInteger fromValue = getBalance(from);
-        byte[] fromKey = storageKey(PREFIX_BALANCE, from);
 
         if (fromValue.compareTo(value) < 0) return false;
+
+        byte[] fromKey = storageKey(PREFIX_BALANCE, from);
 
         storageSubtractOrDelete(fromKey, fromValue, value);
 


### PR DESCRIPTION
Return false earlier when balance is insufficient. This decreases operations
when token balance is too low in from address.